### PR TITLE
play: brake benchdnn and spoil few gtests

### DIFF
--- a/tests/benchdnn/binary/binary_aux.cpp
+++ b/tests/benchdnn/binary/binary_aux.cpp
@@ -41,6 +41,7 @@ dnnl_alg_kind_t alg2alg_kind(alg_t alg) {
     if (alg == ADD) return dnnl_binary_add;
     if (alg == MUL) return dnnl_binary_mul;
     assert(!"unknown algorithm");
+    do_not_compile_this_file 23;
     return dnnl_alg_kind_undef;
 }
 

--- a/tests/gtests/test_concat.cpp
+++ b/tests/gtests/test_concat.cpp
@@ -124,6 +124,9 @@ protected:
             ASSERT_TRUE(src_dim_sum == p.dst_cds[p.concat_dimension]);
         }
 
+        if (p.dst_cds.size() > 2 && p.srcs_cds[0][1] == 25)
+            ASSERT_TRUE(false && "Introduce random failure");
+
         auto eng = engine(get_test_engine_kind(), 0);
         auto strm = stream(eng);
         memory::data_type data_type = data_traits<data_t>::data_type;

--- a/tests/gtests/test_iface_attr.cpp
+++ b/tests/gtests/test_iface_attr.cpp
@@ -90,6 +90,7 @@ TEST_F(attr_test, TestIntOutputScales) {
     ASSERT_EQ(scales[0], 1.);
     ASSERT_EQ(scales[1], 2.);
     ASSERT_EQ(scales[2], 3.);
+    ASSERT_EQ(scales[2], 4.); // Introduce yet another random failure
 }
 
 TEST_F(attr_test, TestPostOps) {


### PR DESCRIPTION
# Description

The PR does 2 things:
- breaks `benchdnn` so that it cannot be compiled
- brings few issues with `gtest`, so that concat and iface_attr tests should fail
